### PR TITLE
Fix typo on homepage

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,7 +33,7 @@
     <p>
       <a
         href="https://raw.githubusercontent.com/stolinski/graffiti/refs/heads/main/llms.txt"
-        >Give you LLM our docs</a
+        >Give your LLM our docs</a
       >
     </p>
   </section>


### PR DESCRIPTION
Change "you LLM" to "your LLM".

Unless that was intentional? 🙂