### PR TITLE
2 fixes for Tabs

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+export default {
+  singleQuote: false,
+  plugins: ["prettier-plugin-svelte"],
+};

--- a/src/lib/drop-in.css
+++ b/src/lib/drop-in.css
@@ -2581,6 +2581,7 @@
         color: var(--fg);
         font-weight: 600;
         border-bottom-color: var(--primary);
+        pointer-events: none;
       }
 
       /* Tab panel content */
@@ -2627,6 +2628,11 @@
           background: var(--fg-05);
           margin-inline-end: -1px;
           position: relative;
+
+          /* Reset margin on last tab so it aligns with panel border */
+          &:last-of-type {
+            margin-inline-end: 0;
+          }
         }
 
         /* Active tab connects to panel */


### PR DESCRIPTION
1. [Issue #14](https://github.com/stolinski/graffiti/issues/14) boxed version of Tabs fix for misalignment right border of last tab and tab content.

2. [Issue #15](https://github.com/stolinski/graffiti/issues/15) fix for clicking alrready open tab would hide the content

Had to include prettier.config.js so I didn't overwrite your double quote preference with my global