### PR TITLE
clarify `.fs-*` needs `.fluid` on non-text elements

### DIFF
--- a/skills/graffiti-best-practices/references/ANTI_PATTERNS.md
+++ b/skills/graffiti-best-practices/references/ANTI_PATTERNS.md
@@ -466,3 +466,22 @@ Apply the role-first decision tree in `CHEAT_SHEET.md` and `COMPONENT_INTENT_MAT
 2. If none exists, use `<span class="icon" aria-hidden="true">` with a placeholder Unicode glyph until the user supplies a real source.
 3. Never include a third-party icon CDN reference in output unless explicitly requested.
 4. Never invent SVG icons more complex than a basic shape.
+
+---
+
+## AP-016: Fluid Size Utility (`.fs-*`) on a Non-Text Element
+
+### Detection heuristics
+
+- `.fs-xs` / `.fs-s` / … on a bare `<span>` or `<div>` without `.fluid`
+- "Small" caption/meta text that renders at the parent's size
+
+### Why this is problematic
+
+- `.fs-*` only set `--fl`; `font-size: var(--fluid-type)` applies to text elements only (`h1`–`h6`, `p`, `li`, `.tag`, `.fluid`, form controls, `a`, `th`, `td`, `label`)
+- A bare `<span>` / `<div>` is not in that list, so the class is inert — it inherits the parent's size
+
+### Preferred direction
+
+- Add `.fluid` beside `.fs-*` (`<span class="fluid fs-xs">`), or use a text element (`<p class="fs-xs">`)
+- For a static small size, set a rem on a project class (as `.log-card` does), not `.fs-*`

--- a/skills/graffiti-best-practices/references/CHEAT_SHEET.md
+++ b/skills/graffiti-best-practices/references/CHEAT_SHEET.md
@@ -139,6 +139,7 @@ When the user says "container", "wrapper", "section" without a role: default to 
 | ---------------------------------------------------------- | ------------------------------------------------------------------- |
 | Page heading                                               | `<h1>` — heading scale is automatic via `--fl`                      |
 | Make a heading shrink in narrow containers                 | Add `.fc` to the heading or a parent                                |
+| Small text on a `<span>` / `<div>` (not a text element)    | Add `.fluid` beside `.fs-*` — `.fs-*` only set `--fl` (see AP-016)   |
 | Body that softens visually                                 | `.text-muted` / `.text-faint`                                       |
 | Center-aligned text block                                  | `.text-center` (or `.text-end` / `.text-start`)                     |
 | Monospace label                                            | inline `<span class="mono">` or `<code>`                            |

--- a/skills/graffiti-best-practices/references/MOBILE_AND_CONTAINERS.md
+++ b/skills/graffiti-best-practices/references/MOBILE_AND_CONTAINERS.md
@@ -155,10 +155,11 @@ Easy rule: at mobile widths, any interactive element should be ≥ 44px in its s
 
 Graffiti's fluid typography is already mobile-aware — `--fl` scales down via `clamp()` automatically. Don't override `font-size` per breakpoint; trust the fluid system.
 
-Two corollaries:
+Three corollaries:
 
 - Use the `.fc` (fluid-container) class on any narrow container where headings need to shrink relative to the container, not the viewport.
 - Don't ship a "mobile body font of 14px" override. Body text never drops below 16px in well-designed mobile pages, and Graffiti's defaults respect that.
+- The `.fs-*` size utilities only set `--fl`; that becomes a `font-size` only on text elements (`p`, `a`, `li`, `h1`–`h6`, `.tag`, form controls, `th`, `td`, `label`) or an element carrying `.fluid`. To size a bare `<span>` / `<div>`, add `.fluid` (`<span class="fluid fs-xs">`). See AP-016.
 
 ---
 

--- a/skills/graffiti-best-practices/references/RECIPES_COMPONENTS.md
+++ b/skills/graffiti-best-practices/references/RECIPES_COMPONENTS.md
@@ -337,7 +337,7 @@ Use case: clickable article/product cards using the canonical card-as-link varia
   <div class="card-body stack" style="--gap: var(--vs-xs);">
     <span class="tag info">Category</span>
     <strong>Card title</strong>
-    <span class="fs-xs text-muted">Meta line</span>
+    <span class="fluid fs-xs text-muted">Meta line</span>
   </div>
 </a>
 ```

--- a/skills/graffiti-best-practices/references/RECIPES_SECTIONS.md
+++ b/skills/graffiti-best-practices/references/RECIPES_SECTIONS.md
@@ -238,7 +238,7 @@ Use case: conversion close with nav footer.
 <header class="stack" style="--gap: var(--vs-s);">
   <div class="cluster" style="--gap: var(--vs-s);">
     <span class="tag info">Accessibility</span>
-    <span class="fs-xs text-muted">10 min read</span>
+    <span class="fluid fs-xs text-muted">10 min read</span>
   </div>
   <h1>Article title</h1>
   <p class="text-muted">Article dek.</p>


### PR DESCRIPTION
Skill-only fix for #20. `.fs-*` set `--fl`, which only becomes a `font-size` on text elements or an element with `.fluid` — so `.fs-*` on a bare `<span>`/`<div>` is inert. No CSS change; this treats `.fluid` as the intended opt-in and leaves the behavior question in #20 open.

- fix two recipes that put `.fs-xs` on a `<span>` (`RECIPES_COMPONENTS.md`, `RECIPES_SECTIONS.md`)
- `CHEAT_SHEET`: add a Type-table row
- `MOBILE_AND_CONTAINERS`: add a "type at mobile" corollary
- `ANTI_PATTERNS`: add AP-016

Closes #20
